### PR TITLE
Fix median point calculation bug

### DIFF
--- a/src/lib/mapbox.ts
+++ b/src/lib/mapbox.ts
@@ -123,7 +123,9 @@ const calculateMedianPoint = (venues: GeocodedVenue[]): [number, number] => {
   const medianLat = sortedLatValues[Math.floor(sortedLatValues.length / 2)]
 
   const medianPoint: [number, number] =
-    medianLng && medianLat ? [medianLng, medianLat] : [-7.6921, 53.1424]
+    medianLng !== undefined && medianLat !== undefined
+      ? [medianLng, medianLat]
+      : [-7.6921, 53.1424]
 
   return medianPoint
 }


### PR DESCRIPTION
## Summary
- avoid falsey checks when coordinates are 0 in mapbox util

## Testing
- `npm run lint` *(fails: Invalid environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68422fd15d808328a48b134cab16661f